### PR TITLE
Add retro-Japanese theme to main page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -2,15 +2,21 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-4">Glossário Interlinear e análise sintática</h1>
-      <ul className="list-disc pl-6 space-y-2">
-        <li>
-          <Link href="/poems/virgil/bucolics">
-            Virgílio – Bucólicas
-          </Link>
-        </li>
-      </ul>
+    <main className="max-w-xl mx-auto px-4 py-8 bg-white border border-red-200 shadow-sm">
+      <h1 className="font-press text-red-700 text-center text-2xl mb-6">
+        Glossário Interlinear
+      </h1>
+
+      <details open className="mb-4">
+        <summary className="cursor-pointer text-lg text-red-800">Virgílio</summary>
+        <ul className="list-disc pl-6 mt-2 space-y-1 font-jp">
+          <li>
+            <Link href="/poems/virgil/bucolics" className="text-blue-700 hover:underline">
+              Bucólicas
+            </Link>
+          </li>
+        </ul>
+      </details>
     </main>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,14 +2,14 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <main className="max-w-xl mx-auto px-4 py-8 bg-white border border-red-200 shadow-sm">
-      <h1 className="font-press text-red-700 text-center text-2xl mb-6">
-        Glossário Interlinear
+    <main className="max-w-xl mx-auto px-4 py-8 border shadow-sm">
+      <h1 className="text-center text-2xl mb-6">
+        Glossário Interlinear e análise sintática
       </h1>
 
       <details open className="mb-4">
         <summary className="cursor-pointer text-lg text-red-800">Virgílio</summary>
-        <ul className="list-disc pl-6 mt-2 space-y-1 font-jp">
+        <ul className=" pl-6 mt-2 space-y-1 font-jp">
           <li>
             <Link href="/poems/virgil/bucolics" className="text-blue-700 hover:underline">
               Bucólicas

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,3 +5,8 @@
 html {
     background: hsl(60, 14%, 95%);
 }
+
+body {
+    font-family: 'Noto Sans JP', sans-serif;
+    color: #333;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,10 +3,9 @@
 @tailwind utilities;
 
 html {
-    background: hsl(60, 14%, 95%);
+    background: hsl(60, 9%, 98%);
 }
 
 body {
-    font-family: 'Noto Sans JP', sans-serif;
     color: #333;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,10 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        jp: ['"Noto Sans JP"', 'sans-serif'],
+        press: ['"Press Start 2P"', 'cursive'],
+      },
       height: {
         'screen-minus-header': 'calc(100vh - 4rem)',
       },


### PR DESCRIPTION
## Summary
- apply retro styled fonts on index page
- list author in expandable section
- set global font family to Noto Sans JP
- add custom fonts to Tailwind config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68699db990b4832a86614e69cb9d8112